### PR TITLE
fixing variable typo in drupal8 entry

### DIFF
--- a/drupaler-learn-symfony.rst
+++ b/drupaler-learn-symfony.rst
@@ -112,7 +112,7 @@ And for an even lower barrier to entry, try `Silex`_! Here's a Silex app::
     $app = new Silex\Application(); 
 
     $app->get('/drupal/{version}', function($version) use($app) { 
-        return 'You\'re using Drupal '.$version; 
+        return 'You\'re using Drupal '.$app->escape($version); 
     });
 
     $app->run(); 


### PR DESCRIPTION
in the drupal 8 blog entry on the silex code snippet was $version passed and $name used
furthermore i use the $app->escape() method in the closure. just because $app got passed... you also could just remove the use($app)
