### PR TITLE
Update symfony-debugging-form-errors.rst

### DIFF
--- a/symfony-debugging-form-errors.rst
+++ b/symfony-debugging-form-errors.rst
@@ -196,6 +196,27 @@ To find out what variables a field has, just dump them:
 .. code-block:: html+jinja
 
     {{ dump(form.price.vars) }}
+    
+It is also possible to compile a list of all form errors for the current form and display them inside a paragraph tah (or any other formatting you wish to use). This requires some additional looping:
+
+.. code-block:: html+jinja
+
+    {% set messages = [] %}
+    {% for child in form.children %}
+        {% if child.vars.errors|length > 0 %}
+            {% for error in child.vars.errors %}
+                {% set messages = messages|merge([error.message]) %}
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+    {% if messages|length > 0 %}
+        <p>
+            {% for message in messages %}
+                {{ message }}<br />
+            {% endfor %}
+        </p>
+    {% endif %}
+
 
 .. tip::
 


### PR DESCRIPTION
Added an example of how to compile all base-level form errors and display in a single <p> tag