### PR TITLE
Update the blog post about Behat screenshots to support CircleCI 2.0

### DIFF
--- a/circle-ci-behat-screenshots.md
+++ b/circle-ci-behat-screenshots.md
@@ -5,6 +5,11 @@
 on failures and see a list of them on each build. This is madness!
 ***
 
+***TIP
+After August 31, 2018, CircleCI 1.0 will no longer be available This blog post was updated
+to support the new CircleCI 2.0.
+***
+
 For KnpUniversity, we use both [Behat](https://knpuniversity.com/screencast/behat)
 and [CircleCI](https://knpuniversity.com/screencast/phpunit/continuous-integration)
 for continuous integration. The combination works *great*, except for

--- a/circle-ci-behat-screenshots.md
+++ b/circle-ci-behat-screenshots.md
@@ -6,8 +6,8 @@ on failures and see a list of them on each build. This is madness!
 ***
 
 ***TIP
-After August 31, 2018, CircleCI 1.0 will no longer be available This blog post was updated
-to support the new CircleCI 2.0.
+This blog post was updated to support the new CircleCI 2.0 because of CircleCI 1.0
+will no longer be available after August 31, 2018.
 ***
 
 For KnpUniversity, we use both [Behat](https://knpuniversity.com/screencast/behat)
@@ -24,7 +24,7 @@ CI server, you'll see a big error screenshot that tells you so. Sweet!
 
 ## CircleCI Setup
 
-To run our `@javascript` Behat scenarios, we use Selenium2. Our CircleCI 2.0 `config.yml` setup
+To run our `@javascript` Behat scenarios, we use Selenium 2. Our CircleCI 2.0 `config.yml` setup
 (without the screenshot magic) looks like this:
 
 ```yml

--- a/circle-ci-behat-screenshots.md
+++ b/circle-ci-behat-screenshots.md
@@ -6,7 +6,7 @@ on failures and see a list of them on each build. This is madness!
 ***
 
 ***TIP
-This blog post was updated to support the new CircleCI 2.0 because of CircleCI 1.0
+This blog post was updated to support CircleCI 2.0 because CircleCI 1.0
 will no longer be available after August 31, 2018.
 ***
 
@@ -176,10 +176,10 @@ jobs:
           path: var/behat_screenshots/
 ```
 
-The `store_artifacts` is a special to CircleCI 2.0: it uploads a file or a directory you specified
-to the special directory where all artifacts of the current job are placed. After the artifacts
-successfully upload, view them in the Artifacts tab of the Job page in your browser. There is no limit
-on the number of `store_artifacts` steps a job can run. Artifacts will be available after job finishes.
+The `store_artifacts` command is special to CircleCI 2.0: it uploads a file or a directory so
+that, when the job finishes, you can view those files in the Artifacts tab of the Job page in
+your browser. There is no limit on the number of `store_artifacts` steps a job can run. Artifacts
+will be available after the job finishes.
 
 To become a Behat & Mink expert, check out our full
 [BDD, Behat, Mink and other Wonderful Things](https://knpuniversity.com/screencast/behat)


### PR DESCRIPTION
After August 31, 2018, CircleCI 1.0 will no longer be available, so this blog post was updated
to support the new CircleCI 2.0.