### PR TITLE
Adds a warning that using doctrine:migrations:dump-schema will result in foreign key constraints being lost

### DIFF
--- a/clean-up-migrations.md
+++ b/clean-up-migrations.md
@@ -34,9 +34,13 @@ rm -rf migrations/*
 ```
 
 Now, dump the current schema into a new single migration:
-
+> [WARNING] This method don`t dump foreign keys constraints.
 ```terminal
 symfony console doctrine:migrations:dump-schema
+```
+ Instead use:
+ ```terminal
+symfony console doctrine:migrations:diff --from-empty-schema
 ```
 
 The bundle provides one more command that helps to "roll up" the migrations by deleting

--- a/clean-up-migrations.md
+++ b/clean-up-migrations.md
@@ -34,14 +34,19 @@ rm -rf migrations/*
 ```
 
 Now, dump the current schema into a new single migration:
-> [WARNING] This method don`t dump foreign keys constraints.
+
 ```terminal
 symfony console doctrine:migrations:dump-schema
 ```
- Instead use:
+
+***TIP
+ The `doctrine:migrations:dump-schema` command doesn't dump foreign key constraints. Instead,
+ better use:
+ 
  ```terminal
 symfony console doctrine:migrations:diff --from-empty-schema
 ```
+***
 
 The bundle provides one more command that helps to "roll up" the migrations by deleting
 all tracked versions and insert the one version that exists:


### PR DESCRIPTION
Adds a warning that using doctrine:migrations:dump-schema will result in foreign key constraints being lost. Adds command to generate safe single migration.